### PR TITLE
Remove first intro slide; fix typo

### DIFF
--- a/slides/intro/index.html
+++ b/slides/intro/index.html
@@ -45,11 +45,6 @@
 
 				<!-- Intro -->
 				<section>
-					<h1>MDN Content Kits</h1>
-					<h3>Open-Source Teaching Resources</h3>
-				</section>
-
-				<section>
 					<h1>Service Worker</h1>
 					<h4>Introduction</h4>
 				</section>
@@ -57,7 +52,7 @@
 	            <section>
 	                <div class="sl-block" data-block-type="text" style="width: 800px; left: 80px; top: 245px; height: auto;">
 	                    <div class="sl-block-content">
-	                        <h2>First, there were AppCache</h2>
+	                        <h2>First, there was AppCache</h2>
 	                    </div>
 	                </div>
 	                <div class="sl-block" data-block-type="text" style="width: 800px; left: 80px; top: 328px; height: auto;">


### PR DESCRIPTION
The first intro slide that says this is a content kit is irrelevant. The audience doesn't need to know that they are learning from a content kit, they just need to know they're learning about service workers.
